### PR TITLE
feat/#1 MetalKit으로 Metal 렌더링 화면 표시하기

### DIFF
--- a/Projects/learnMetal/learnMetal.xcodeproj/project.pbxproj
+++ b/Projects/learnMetal/learnMetal.xcodeproj/project.pbxproj
@@ -6,6 +6,11 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		0602BE3C2E4CB027007E6F6B /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0602BE322E4CAC9D007E6F6B /* Metal.framework */; };
+		0602BE3F2E4CB028007E6F6B /* MetalKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0602BE342E4CACA4007E6F6B /* MetalKit.framework */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		0602BE152E4CAB7F007E6F6B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -27,6 +32,8 @@
 		0602BE072E4CAB7D007E6F6B /* learnMetal.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = learnMetal.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0602BE142E4CAB7F007E6F6B /* learnMetalTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = learnMetalTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0602BE1E2E4CAB7F007E6F6B /* learnMetalUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = learnMetalUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		0602BE322E4CAC9D007E6F6B /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/Metal.framework; sourceTree = DEVELOPER_DIR; };
+		0602BE342E4CACA4007E6F6B /* MetalKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MetalKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.0.sdk/System/Library/Frameworks/MetalKit.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -52,6 +59,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0602BE3C2E4CB027007E6F6B /* Metal.framework in Frameworks */,
+				0602BE3F2E4CB028007E6F6B /* MetalKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -78,6 +87,7 @@
 				0602BE092E4CAB7D007E6F6B /* learnMetal */,
 				0602BE172E4CAB7F007E6F6B /* learnMetalTests */,
 				0602BE212E4CAB7F007E6F6B /* learnMetalUITests */,
+				0602BE312E4CAC9C007E6F6B /* Frameworks */,
 				0602BE082E4CAB7D007E6F6B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -90,6 +100,15 @@
 				0602BE1E2E4CAB7F007E6F6B /* learnMetalUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		0602BE312E4CAC9C007E6F6B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0602BE342E4CACA4007E6F6B /* MetalKit.framework */,
+				0602BE322E4CAC9D007E6F6B /* Metal.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/Projects/learnMetal/learnMetal/ContentView.swift
+++ b/Projects/learnMetal/learnMetal/ContentView.swift
@@ -5,17 +5,14 @@
 //  Created by Hyeok Cho on 8/13/25.
 //
 
+//  ContentView.swift
+//  SwiftUI view that presents the MetalKit-backed MetalView
 import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        MetalView()
+            .ignoresSafeArea()
     }
 }
 

--- a/Projects/learnMetal/learnMetal/MetalView.swift
+++ b/Projects/learnMetal/learnMetal/MetalView.swift
@@ -19,14 +19,14 @@ struct MetalView: UIViewRepresentable {
         mtkView.device = MTLCreateSystemDefaultDevice()
         mtkView.clearColor = MTLClearColorMake(0.0, 0.5, 1.0, 1.0)
         mtkView.enableSetNeedsDisplay = true
-        let renderer = AAPLRenderer(metalKitView: mtkView)
+        let renderer = Renderer(metalKitView: mtkView)
         mtkView.delegate = renderer
         context.coordinator.renderer = renderer
         return mtkView
     }
     func updateUIView(_ uiView: MTKView, context: Context) {}
     class Coordinator {
-        var renderer: AAPLRenderer?
+        var renderer: Renderer?
     }
 }
 

--- a/Projects/learnMetal/learnMetal/MetalView.swift
+++ b/Projects/learnMetal/learnMetal/MetalView.swift
@@ -1,0 +1,36 @@
+//
+//  MetalView.swift
+//  learnMetal
+//
+//  Created by Hyeok Cho on 8/13/25.
+//
+
+// MetalView wraps MTKView for SwiftUI
+
+import SwiftUI
+import MetalKit
+
+struct MetalView: UIViewRepresentable {
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+    func makeUIView(context: Context) -> MTKView {
+        let mtkView = MTKView()
+        mtkView.device = MTLCreateSystemDefaultDevice()
+        mtkView.clearColor = MTLClearColorMake(0.0, 0.5, 1.0, 1.0)
+        mtkView.enableSetNeedsDisplay = true
+        let renderer = AAPLRenderer(metalKitView: mtkView)
+        mtkView.delegate = renderer
+        context.coordinator.renderer = renderer
+        return mtkView
+    }
+    func updateUIView(_ uiView: MTKView, context: Context) {}
+    class Coordinator {
+        var renderer: AAPLRenderer?
+    }
+}
+
+
+#Preview {
+    MetalView()
+}

--- a/Projects/learnMetal/learnMetal/Renderer.swift
+++ b/Projects/learnMetal/learnMetal/Renderer.swift
@@ -1,0 +1,35 @@
+//
+//  Renderer.swift
+//  learnMetal
+//
+//  Created by Hyeok Cho on 8/13/25.
+//
+
+import MetalKit
+
+class AAPLRenderer: NSObject, MTKViewDelegate {
+    let device: MTLDevice
+    let commandQueue: MTLCommandQueue
+
+    init(metalKitView: MTKView) {
+        self.device = metalKitView.device ?? MTLCreateSystemDefaultDevice()!
+        self.commandQueue = self.device.makeCommandQueue()!
+        super.init()
+    }
+    
+    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
+        // Resize handling if needed
+    }
+    
+    func draw(in view: MTKView) {
+        guard let renderPassDescriptor = view.currentRenderPassDescriptor, let drawable = view.currentDrawable else {
+            return
+        }
+        let commandBuffer = commandQueue.makeCommandBuffer()!
+        if let commandEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) {
+            commandEncoder.endEncoding()
+        }
+        commandBuffer.present(drawable)
+        commandBuffer.commit()
+    }
+}

--- a/Projects/learnMetal/learnMetal/Renderer.swift
+++ b/Projects/learnMetal/learnMetal/Renderer.swift
@@ -7,7 +7,7 @@
 
 import MetalKit
 
-class AAPLRenderer: NSObject, MTKViewDelegate {
+class Renderer: NSObject, MTKViewDelegate {
     let device: MTLDevice
     let commandQueue: MTLCommandQueue
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #1 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->
-MetalKit을 이용하여 파란색 텍스쳐를 생성하고 이를 관리하는 드로어블을 화면에 렌더링 하였습니다.


```
//뷰 코드 

//MTKView()를 생성합니다.
let mtkView = MTKView()

//MTKView의 device프로퍼티에서 MTLCreateSystemDefaultDevice()로 디바이스 정보를 가져옵니다.
mtkView.device = MTLCreateSystemDefaultDevice()

//MTLClearColorMake(0.0, 0.5, 1.0, 1.0)를 이용하여 배경 컬러를 설정합니다.
mtkView.clearColor = MTLClearColorMake(0.0, 0.5, 1.0, 1.0)

//SetNeedsDisplay()가 호출될 때만 draw(in: )을 실행합니다.
mtkView.enableSetNeedsDisplay = true

//뷰 딜리게이트에 렌더러를 위임합니다.
let renderer = Renderer(metalKitView: mtkView)
mtkView.delegate = renderer
context.coordinator.renderer = renderer
return mtkView
```

```
//렌더러는 MTKViewDelegate를 지원해야 합니다.
class Renderer: NSObject, MTKViewDelegate {
    let device: MTLDevice
    let commandQueue: MTLCommandQueue

    init(metalKitView: MTKView) {
        self.device = metalKitView.device ?? MTLCreateSystemDefaultDevice()!
        self.commandQueue = self.device.makeCommandQueue()!
        super.init()
    }

    //프로토콜 제약 1: mtkView
    func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {
        // Resize handling if needed
    }
    
    //프로토콜 제약 2: draw
    func draw(in view: MTKView) {
        //렌더 패스 디스크립터를 설정해줍니다.
        guard let renderPassDescriptor = view.currentRenderPassDescriptor, let drawable = view.currentDrawable else {
            return
        }
       //커맨드버퍼를 생성합니다.
        let commandBuffer = commandQueue.makeCommandBuffer()!
        
        //렌더 패스에 랜더 패스 디스크립터를 인자로 설정합니다.
        if let commandEncoder = commandBuffer.makeRenderCommandEncoder(descriptor: renderPassDescriptor) {
            //인코딩 종료 메서드를 이용하여 GPU에게 인코딩 명령이 여기까지임을 송신합니다.
            commandEncoder.endEncoding()
        }
        //커맨드버퍼에 드로어블을 전달합니다.
        commandBuffer.present(drawable)

        //커맨드버퍼를 실행합니다.
        commandBuffer.commit()
    }
}
```


---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="520" height="688" alt="스크린샷 2025-08-13 22 00 14" src="https://github.com/user-attachments/assets/0d3ba366-967f-46c2-82a9-1ebad823cf33" />


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->


---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->


---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

